### PR TITLE
Replace commas by semicolons

### DIFF
--- a/ccs-template.tex
+++ b/ccs-template.tex
@@ -33,7 +33,7 @@ Your abstract should go here. You will also need to upload a plain-text abstract
 \ccsdesc{Security and privacy~Use https://dl.acm.org/ccs.cfm to generate actual concepts section for your paper}
 % -- end of section to replace with generated code
 
-\keywords{template, formatting, pickling} % TODO: replace with your keywords
+\keywords{template; formatting; pickling} % TODO: replace with your keywords
 
 \maketitle
 


### PR DESCRIPTION
According to https://www.sheridanprinting.com/typedept/CCS-license.pdf , keywords need to be separated by semicolons.